### PR TITLE
Support memory matching to enable QEMU system tracing

### DIFF
--- a/qemu_system_plugin/.gitignore
+++ b/qemu_system_plugin/.gitignore
@@ -1,0 +1,1 @@
+libqtrace.so

--- a/qemu_system_plugin/Makefile
+++ b/qemu_system_plugin/Makefile
@@ -7,7 +7,7 @@
 #
 
 # BUILD_DIR := /opt/qemu/build
-BUILD_DIR := ../../qemu/build
+BUILD_DIR := ../qemu/build
 
 include $(BUILD_DIR)/config-host.mak
 
@@ -24,6 +24,7 @@ CFLAGS = $(GLIB_CFLAGS)
 CFLAGS += -fPIC
 CFLAGS += $(if $(findstring no-psabi,$(QEMU_CFLAGS)),-Wpsabi)
 CFLAGS += -I$(SRC_PATH)/include/qemu
+CFLAGS += -Wall
 
 all: $(SONAMES)
 

--- a/qemu_system_plugin/Makefile
+++ b/qemu_system_plugin/Makefile
@@ -1,0 +1,40 @@
+# -*- Mode: makefile -*-
+#
+# This Makefile example is fairly independent from the main makefile
+# so users can take and adapt it for their build. We only really
+# include config-host.mak so we don't have to repeat probing for
+# cflags that the main configure has already done for us.
+#
+
+# BUILD_DIR := /opt/qemu/build
+BUILD_DIR := ../../qemu/build
+
+include $(BUILD_DIR)/config-host.mak
+
+VPATH += $(SRC_PATH)/contrib/plugins
+
+NAMES :=
+NAMES += qtrace
+
+SONAMES := $(addsuffix .so,$(addprefix lib,$(NAMES)))
+
+# The main QEMU uses Glib extensively so it's perfectly fine to use it
+# in plugins (which many example do).
+CFLAGS = $(GLIB_CFLAGS)
+CFLAGS += -fPIC
+CFLAGS += $(if $(findstring no-psabi,$(QEMU_CFLAGS)),-Wpsabi)
+CFLAGS += -I$(SRC_PATH)/include/qemu
+
+all: $(SONAMES)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+lib%.so: %.o
+	$(CC) -shared -Wl,-soname,$@ -o $@ $^ $(LDLIBS)
+
+clean:
+	rm -f *.o *.so *.d
+	rm -Rf .libs
+
+.PHONY: all clean

--- a/qemu_system_plugin/qemu-patches/0001-plugin-Support-reading-memory-syscalls-in-QEMU-syste.patch
+++ b/qemu_system_plugin/qemu-patches/0001-plugin-Support-reading-memory-syscalls-in-QEMU-syste.patch
@@ -1,0 +1,58 @@
+From f6e8049950bfffcf0b1ea7637dfd642b265ded36 Mon Sep 17 00:00:00 2001
+From: Matt Borgerson <contact@mborgerson.com>
+Date: Tue, 16 Feb 2021 20:17:00 -0700
+Subject: [PATCH] plugin: Support reading memory, syscalls in QEMU system
+
+---
+ include/qemu/qemu-plugin.h | 2 ++
+ plugins/api.c              | 5 +++++
+ target/arm/op_helper.c     | 6 ++++++
+ 3 files changed, 13 insertions(+)
+
+diff --git a/include/qemu/qemu-plugin.h b/include/qemu/qemu-plugin.h
+index bab8b0d4b3..82cc932399 100644
+--- a/include/qemu/qemu-plugin.h
++++ b/include/qemu/qemu-plugin.h
+@@ -410,4 +410,6 @@ int qemu_plugin_n_max_vcpus(void);
+  */
+ void qemu_plugin_outs(const char *string);
+ 
++bool qemu_plugin_mem_read(unsigned int vcpu_index, uint64_t vaddr, uint64_t len, void *data);
++
+ #endif /* QEMU_PLUGIN_API_H */
+diff --git a/plugins/api.c b/plugins/api.c
+index bbdc5a4eb4..0cb1653be2 100644
+--- a/plugins/api.c
++++ b/plugins/api.c
+@@ -303,6 +303,11 @@ uint64_t qemu_plugin_hwaddr_device_offset(const struct qemu_plugin_hwaddr *haddr
+     return 0;
+ }
+ 
++bool qemu_plugin_mem_read(unsigned int vcpu_index, uint64_t vaddr, uint64_t len, void *data)
++{
++    return cpu_memory_rw_debug(qemu_get_cpu(vcpu_index), vaddr, data, len, false) >= 0;
++}
++
+ /*
+  * Queries to the number and potential maximum number of vCPUs there
+  * will be. This helps the plugin dimension per-vcpu arrays.
+diff --git a/target/arm/op_helper.c b/target/arm/op_helper.c
+index ff91fe6121..2fd32555da 100644
+--- a/target/arm/op_helper.c
++++ b/target/arm/op_helper.c
+@@ -51,6 +51,12 @@ static CPUState *do_raise_exception(CPUARMState *env, uint32_t excp,
+     env->exception.syndrome = syndrome;
+     env->exception.target_el = target_el;
+ 
++    if (excp == EXCP_SWI) {
++        unsigned int n = env->regs[7]; // Assumption may not always hold!!
++        qemu_plugin_vcpu_syscall(cs, n, env->regs[0], env->regs[1],
++            env->regs[2], env->regs[3], env->regs[4], env->regs[5], 0, 0);
++    }
++
+     return cs;
+ }
+ 
+-- 
+2.25.1
+

--- a/qemu_system_plugin/qtrace.c
+++ b/qemu_system_plugin/qtrace.c
@@ -1,0 +1,269 @@
+/*
+ * QEMU-SYSTEM BASED TRACER
+ * ------------------------
+ * This plugin supports tracing a target process running within a full QEMU
+ * system instance. To identify execution of the target process among other
+ * processes running in the system, this plugin supports a simple virtual memory
+ * matching test.
+ *
+ * When launching the plugin, specify one or more <addr>=<data> arguments for
+ * the plugin, where <addr> is the hex virtual memory address and <data> are the
+ * base64 encoded bytes to check.
+ *
+ * Before attempting to perform QEMU system based tracing, make sure to apply
+ * the patch that accompanies this plugin, which adds support for reading memory
+ *
+ * - Apply patches in qemu-patches to QEMU v5.2.0
+ * - Build this plugin
+ * - When launching QEMU, add plugin and plugin arguments as follows:
+ *   -plugin file=$PWD/libqtrace.so,arg="<addr>=<data>"
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <qemu-plugin.h>
+
+#define TRACE_MAX_BB_ADDRS  0x1000
+#define TRACE_FD            255
+
+#define DEBUG 0
+
+/*
+ * Enable for version of memory-read API implementation which works on unpatched
+ * QEMU. This is dangerous, however...
+ */
+#define NO_PATCH_HACK 0
+
+QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
+
+enum reason {
+    trace_full = 0,
+    trace_syscall_start = 1,
+    trace_syscall_end = 2,
+};
+
+struct trace_info {
+    int64_t syscall_num;
+    union {
+        struct {
+            uint64_t syscall_a1;
+            uint64_t syscall_a2;
+            uint64_t syscall_a3;
+            uint64_t syscall_a4;
+            uint64_t syscall_a5;
+            uint64_t syscall_a6;
+            uint64_t syscall_a7;
+            uint64_t syscall_a8;
+        };
+        int64_t syscall_ret;
+    };
+};
+#define EMPTY_INFO (const struct trace_info) { 0 }
+
+struct {
+    struct {
+        enum reason reason;
+        uint64_t num_addrs;
+        struct trace_info info;
+    } header;
+    uint64_t bb_addrs[TRACE_MAX_BB_ADDRS];
+} trace;
+
+static inline void trace_flush(enum reason reason, struct trace_info info) {
+    size_t size;
+    uint64_t response;
+
+    trace.header.reason = reason;
+    trace.header.info = info;
+
+    size = sizeof(trace.header) + (trace.header.num_addrs * sizeof(uint64_t));
+    assert(write(TRACE_FD, &trace, size) == size);
+#if !DEBUG
+    assert(read(TRACE_FD, &response, sizeof(response)) == sizeof(response));
+#endif
+
+#if DEBUG
+    fprintf(stderr, "syscall(%ld)\n", trace.header.info.syscall_num);
+#endif
+
+    trace.header.reason = 0;
+    trace.header.num_addrs = 0;
+    trace.header.info = EMPTY_INFO;
+}
+
+static inline void trace_add_bb_addr(uint64_t addr)
+{
+    trace.bb_addrs[trace.header.num_addrs++] = addr;
+    if (trace.header.num_addrs == TRACE_MAX_BB_ADDRS)
+        trace_flush(trace_full, EMPTY_INFO);
+}
+
+/*
+ * Rudimentary test to check if target process is currently running: "Memory
+ * Check" structure, which specifies a simple virtual memory byte-match test to
+ * determine whether a particular callback should occur or not.
+ */
+struct mem_check {
+    uint64_t addr;
+    gsize len;
+    const guchar *data;
+};
+static struct mem_check *mem_checks;
+static size_t num_mem_checks;
+static char *mem_check_buf;
+static int mem_check_buf_size = 0;
+
+#if NO_PATCH_HACK
+typedef uint32_t target_ulong; // Target-dependent! Same size as virtual address
+void *qemu_get_cpu(int index);
+int cpu_memory_rw_debug(void *cpu, target_ulong addr, void *ptr, target_ulong len, bool is_write);
+bool qemu_plugin_mem_read__hack(unsigned int vcpu_index, uint64_t vaddr, uint64_t len, void *data) {
+    return cpu_memory_rw_debug(qemu_get_cpu(vcpu_index), vaddr, data, len, false) >= 0;
+}
+#define qemu_plugin_mem_read qemu_plugin_mem_read__hack
+#endif
+
+/*
+ * Decode one of the plugin command line arguments specifying a mem check
+ */
+static void decode_mem_check(char *s)
+{
+    struct mem_check c;
+
+    /* Decode check argument */
+    if (sscanf(s, "%lx=", &c.addr) != 1) return;
+    char *data_b64 = strchr(s, '=') + 1;
+    if (!*data_b64) return;
+    c.data = g_base64_decode(data_b64, &c.len);
+    if (c.len == 0) return;
+
+    num_mem_checks++;
+
+    /* Reallocate temporary check buffer to maximum check length */
+    if (c.len > mem_check_buf_size) {
+        mem_check_buf = realloc(mem_check_buf, c.len);
+        assert(mem_check_buf != NULL);
+    }
+
+    /* Add check */
+    mem_checks = reallocarray(mem_checks, num_mem_checks, sizeof(c));
+    mem_checks[num_mem_checks-1] = c;
+}
+
+/*
+ * Determine if this particular callback (TB translate, exec) should execute
+ * based on whether the target process is loaded or not.
+ */
+static bool should_instrument(void)
+{
+    for (size_t i = 0; i < num_mem_checks; i++) {
+        struct mem_check *c = &mem_checks[i];
+        if (!qemu_plugin_mem_read(0, c->addr, c->len, mem_check_buf))
+            return false; /* Failed to read */
+        if (memcmp(c->data, mem_check_buf, c->len))
+            return false; /* Mismatch */
+    }
+
+    return true;
+}
+
+static void vcpu_tb_exec(unsigned int cpu_index, void *udata)
+{
+    if (!should_instrument()) return;
+
+    uint64_t addr = (uint64_t) udata;
+
+#if DEBUG
+    fprintf(stderr, "exec(0x%lx)\n", addr);
+#endif
+
+    trace_add_bb_addr(addr);
+}
+
+static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb *tb)
+{
+    if (!should_instrument()) return;
+
+    uint64_t addr = qemu_plugin_tb_vaddr(tb);
+
+    qemu_plugin_register_vcpu_tb_exec_cb(tb, vcpu_tb_exec,
+                                         QEMU_PLUGIN_CB_NO_REGS,
+                                         (void *) addr);
+}
+
+static void vcpu_syscall(qemu_plugin_id_t id, unsigned int vcpu_index,
+                         int64_t num, uint64_t a1, uint64_t a2,
+                         uint64_t a3, uint64_t a4, uint64_t a5,
+                         uint64_t a6, uint64_t a7, uint64_t a8)
+{
+    if (!should_instrument()) return;
+
+    struct trace_info info;
+    info.syscall_num = num;
+    info.syscall_a1 = a1;
+    info.syscall_a2 = a2;
+    info.syscall_a3 = a3;
+    info.syscall_a4 = a4;
+    info.syscall_a5 = a5;
+    info.syscall_a6 = a6;
+    info.syscall_a7 = a7;
+    info.syscall_a8 = a8;
+
+    trace_flush(trace_syscall_start, info);
+}
+
+static void vcpu_syscall_ret(qemu_plugin_id_t id, unsigned int vcpu_index,
+                             int64_t num, int64_t ret)
+{
+    if (!should_instrument()) return;
+
+    struct trace_info info;
+    info.syscall_num = num;
+    info.syscall_ret = ret;
+
+    trace_flush(trace_syscall_end, info);
+}
+
+QEMU_PLUGIN_EXPORT
+int qemu_plugin_install(qemu_plugin_id_t id, const qemu_info_t *info,
+                        int argc, char **argv)
+{
+    int server_fd;
+    int client_fd;
+    struct sockaddr_in server_addr;
+
+    for (int i = 0; i < argc; i++) {
+        decode_mem_check(argv[i]);
+    }
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
+    server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &(int){1}, sizeof(int));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = INADDR_ANY;
+    server_addr.sin_port = htons(4242);
+    bind(server_fd, (struct sockaddr *) &server_addr, sizeof(server_addr));
+    listen(server_fd, 1);
+    client_fd = accept(server_fd, NULL, NULL);
+
+    assert(dup2(client_fd, TRACE_FD) != -1);
+    assert(close(client_fd) != -1);
+    assert(close(server_fd) != -1);
+
+    qemu_plugin_register_vcpu_tb_trans_cb(id, vcpu_tb_trans);
+    qemu_plugin_register_vcpu_syscall_cb(id, vcpu_syscall);
+    qemu_plugin_register_vcpu_syscall_ret_cb(id, vcpu_syscall_ret);
+
+    return 0;
+}

--- a/qemu_system_plugin/qtrace.c
+++ b/qemu_system_plugin/qtrace.c
@@ -35,7 +35,7 @@
 #define TRACE_MAX_BB_ADDRS  0x1000
 #define TRACE_FD            255
 
-#define DEBUG 0
+#define DEBUG 1
 
 /*
  * Enable for version of memory-read API implementation which works on unpatched
@@ -89,10 +89,6 @@ static inline void trace_flush(enum reason reason, struct trace_info info) {
     assert(write(TRACE_FD, &trace, size) == size);
 #if 0
     assert(read(TRACE_FD, &response, sizeof(response)) == sizeof(response));
-#endif
-
-#if DEBUG
-    fprintf(stderr, "syscall(%ld)\n", trace.header.info.syscall_num);
 #endif
 
     trace.header.reason = 0;
@@ -217,6 +213,10 @@ static void vcpu_syscall(qemu_plugin_id_t id, unsigned int vcpu_index,
     info.syscall_a6 = a6;
     info.syscall_a7 = a7;
     info.syscall_a8 = a8;
+
+#if DEBUG
+    fprintf(stderr, "syscall(%ld)\n", num);
+#endif
 
     trace_flush(trace_syscall_start, info);
 }

--- a/qemu_system_plugin/qtrace.c
+++ b/qemu_system_plugin/qtrace.c
@@ -87,7 +87,7 @@ static inline void trace_flush(enum reason reason, struct trace_info info) {
 
     size = sizeof(trace.header) + (trace.header.num_addrs * sizeof(uint64_t));
     assert(write(TRACE_FD, &trace, size) == size);
-#if !DEBUG
+#if 0
     assert(read(TRACE_FD, &response, sizeof(response)) == sizeof(response));
 #endif
 

--- a/qemu_system_plugin/test.py
+++ b/qemu_system_plugin/test.py
@@ -12,7 +12,7 @@ import tempfile
 import IPython
 
 # pwntools debugging
-context.log_level = 'debug'
+# context.log_level = 'debug'
 
 images_base = '../../images'
 qemu = '../../qemu/build/arm-softmmu/qemu-system-arm'

--- a/qemu_system_plugin/test.py
+++ b/qemu_system_plugin/test.py
@@ -127,7 +127,17 @@ gdb_script_fd.flush()
 gdb_process = process(gdb_path + ' -x ' + gdb_script_fd.name, True)
 
 # Manually decide when to end things...
-IPython.embed()
+# IPython.embed()
+
+# Use debug output to trace (FIXME: integrate with existing binary trace stream, not this text parsing)
+while True:
+	l = p.recvline()
+	syscall_m = re.findall(r'syscall\((\d+)\)', l.decode('utf-8'))
+	if syscall_m:
+		print('syscall:' + str(syscall_m))
+	exec_m = re.findall(r'exec\((0x[a-fA-F0-9]+)\)', l.decode('utf-8'))
+	if exec_m:
+		print('exec:' + str(exec_m))
 
 gdb_process.kill()
 p.kill()

--- a/qemu_system_plugin/test.py
+++ b/qemu_system_plugin/test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from pwn import *
+import os.path
+import pathlib
+
+# pwntools debugging
+context.log_level = 'debug'
+
+images_base = '../../images'
+qemu = '../../qemu/build/arm-softmmu/qemu-system-arm'
+
+# Survey target binary to list of memory regions to test against to determine
+# if target binary is running in QEMU system
+e = ELF('crashing-http-server')
+args = ''
+for s in ['main']:
+	addr = e.symbols[s]
+	args += 'arg="%x=%s"' % (addr ,b64e(e.read(addr, 32)))
+
+# QEMU launch params
+cmd = f'''{qemu} \
+	-M vexpress-a9 \
+	-kernel {images_base}/zImage \
+	-dtb {images_base}/vexpress-v2p-ca9.dtb \
+	-drive file={images_base}/rootfs.qcow2,if=sd \
+	-append "root=/dev/mmcblk0 console=ttyAMA0,115200" \
+	-net nic -net user,hostfwd=tcp:127.0.0.1:2222-:2222,hostfwd=tcp:127.0.0.1:8080-:8080 \
+	-display none -nographic \
+	-plugin file={pathlib.Path(__file__).parent.absolute() / "libqtrace.so"},{args}
+'''
+
+# Launch QEMU system
+p = process(cmd, True)
+
+# Connect to tracer
+sleep(0.5)
+tracer = remote('127.0.0.1', 4242)
+
+# Wait for login prompt
+p.recvuntil('login:')
+p.sendline('root')
+p.recvuntil('#')
+
+# Note: This expects that netcat is installed on the system. Alternatively you
+# could pipe files through your shell, read/write them on disk before and after
+# launching, etc
+def send_file(path, outfile=None):
+	outfile = outfile or os.path.basename(path)
+
+	# Open a socket on guest (forwarded through QEMU above)
+	p.sendline('nc -l -p 2222 > ' + outfile)
+	sleep(0.125)
+
+	# Pipe the file over
+	s = remote('127.0.0.1', 2222)
+	s.send(open(path, 'rb').read())
+	s.close()
+
+	# Wait for shell to come back and mark the file executable
+	p.recvuntil('#')
+	p.sendline('chmod +x ' + outfile)
+	p.recvuntil('#')
+
+def recv_file(path, outfile=None):
+	outfile = outfile or os.path.basename(path)
+
+	# Open a socket on guest (forwarded through QEMU above)
+	p.sendline('cat ' + path + ' | nc -l -p 2222 -c')
+	sleep(0.125)
+
+	# Pipe the file over
+	s = remote('127.0.0.1', 2222)
+	open(outfile, 'wb').write(s.recvall())
+	s.close()
+
+	# Wait for shell to come back
+	p.recvuntil('#')
+
+def cmd(s):
+	print('Executing: ' + s)
+	p.sendline(s)
+	p.recvuntil('#')
+
+# Enable core dumps
+cmd('ulimit -c unlimited')
+cmd('echo "core" > /proc/sys/kernel/core_pattern')
+
+# Launch crashing HTTP Server, serve on port 8080
+send_file('crashing-http-server')
+cmd('./crashing-http-server -p 8080')
+
+p.kill()

--- a/qemu_system_plugin/test.py
+++ b/qemu_system_plugin/test.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
+"""
+This is a hacky test script. It's littered with sleeps to make things work and
+relies on dumb string processing to execute shell commands.
+"""
+
 from pwn import *
 import os.path
 import pathlib
+import re
+import tempfile
+import IPython
 
 # pwntools debugging
 context.log_level = 'debug'
 
 images_base = '../../images'
 qemu = '../../qemu/build/arm-softmmu/qemu-system-arm'
+gdb_path = '../../buildroot-2020.02.9/output/build/host-gdb-8.2.1/gdb/gdb'
 
 # Survey target binary to list of memory regions to test against to determine
 # if target binary is running in QEMU system
-e = ELF('crashing-http-server')
+target = 'crashing-http-server'
+e = ELF(target)
 args = ''
 for s in ['main']:
 	addr = e.symbols[s]
@@ -24,9 +34,10 @@ cmd = f'''{qemu} \
 	-dtb {images_base}/vexpress-v2p-ca9.dtb \
 	-drive file={images_base}/rootfs.qcow2,if=sd \
 	-append "root=/dev/mmcblk0 console=ttyAMA0,115200" \
-	-net nic -net user,hostfwd=tcp:127.0.0.1:2222-:2222,hostfwd=tcp:127.0.0.1:8080-:8080 \
+	-net nic -net user,hostfwd=tcp:127.0.0.1:2222-:2222,hostfwd=tcp:127.0.0.1:8080-:8080,hostfwd=tcp:127.0.0.1:1234-:1234 \
 	-display none -nographic \
-	-plugin file={pathlib.Path(__file__).parent.absolute() / "libqtrace.so"},{args}
+	-plugin file={pathlib.Path(__file__).parent.absolute() / "libqtrace.so"},{args} \
+	-snapshot
 '''
 
 # Launch QEMU system
@@ -41,6 +52,12 @@ p.recvuntil('login:')
 p.sendline('root')
 p.recvuntil('#')
 
+def cmd(s):
+	print('Executing: ' + s)
+	p.sendline(s)
+	sleep(0.25)
+	return p.recvuntil('#')
+
 # Note: This expects that netcat is installed on the system. Alternatively you
 # could pipe files through your shell, read/write them on disk before and after
 # launching, etc
@@ -49,7 +66,7 @@ def send_file(path, outfile=None):
 
 	# Open a socket on guest (forwarded through QEMU above)
 	p.sendline('nc -l -p 2222 > ' + outfile)
-	sleep(0.125)
+	sleep(0.25)
 
 	# Pipe the file over
 	s = remote('127.0.0.1', 2222)
@@ -58,15 +75,15 @@ def send_file(path, outfile=None):
 
 	# Wait for shell to come back and mark the file executable
 	p.recvuntil('#')
-	p.sendline('chmod +x ' + outfile)
-	p.recvuntil('#')
+
+	cmd('chmod +x ' + outfile)
 
 def recv_file(path, outfile=None):
 	outfile = outfile or os.path.basename(path)
 
 	# Open a socket on guest (forwarded through QEMU above)
 	p.sendline('cat ' + path + ' | nc -l -p 2222 -c')
-	sleep(0.125)
+	sleep(0.25)
 
 	# Pipe the file over
 	s = remote('127.0.0.1', 2222)
@@ -76,17 +93,41 @@ def recv_file(path, outfile=None):
 	# Wait for shell to come back
 	p.recvuntil('#')
 
-def cmd(s):
-	print('Executing: ' + s)
-	p.sendline(s)
-	p.recvuntil('#')
 
 # Enable core dumps
 cmd('ulimit -c unlimited')
 cmd('echo "core" > /proc/sys/kernel/core_pattern')
 
+# Launch GDB server
+cmd('gdbserver --multi 0.0.0.0:1234 &')
+
 # Launch crashing HTTP Server, serve on port 8080
 send_file('crashing-http-server')
-cmd('./crashing-http-server -p 8080')
+cmd('./crashing-http-server -p 8080 &')
 
+# Get crashing-http-server pid
+pid = int(re.findall(r'TARGET_PID=(\d+)', cmd("echo TARGET_PID=$!").decode('utf-8'))[0])
+
+# Fire up gdb to start collecting core dumps
+coredump_addr = e.symbols['handle_connection']
+script_src = f'''
+set pagination off
+target extended-remote 127.0.0.1:1234
+attach {pid}
+break *{hex(coredump_addr)}
+commands
+generate-core-file {target + '.core'}
+continue
+end
+continue
+'''
+gdb_script_fd = tempfile.NamedTemporaryFile('w')
+gdb_script_fd.write(script_src)
+gdb_script_fd.flush()
+gdb_process = process(gdb_path + ' -x ' + gdb_script_fd.name, True)
+
+# Manually decide when to end things...
+IPython.embed()
+
+gdb_process.kill()
 p.kill()


### PR DESCRIPTION
This patch adds:
- Support for "memory checks" to enable QEMU system based target process tracing through simple (but effective) memory region matching.
- Support for tracing syscalls in QEMU system, for ARM only at the moment but I'll add MIPS too. 

I've opted to place it in a new `qemu_system_plugin` directory to minimize any intrusion, but this can be easily merged with existing plugin code as well.